### PR TITLE
Fixed client iPerfer section `received` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Data should be sent in chunks of 80KB and the data should be all zeros (note: th
 
 `Sent=X KB, Rate=Y Mbps, RTT=Z ms`
 
-where X stands for the total number of bytes received (in kilobytes), Y stands for the rate at which traffic could be read in megabits per second (Mbps), and Z stands for the estimated RTT (in milliseconds). Note X and Z should be integers and Y should be a decimal with **three digits** after the decimal mark (e.g. `spdlog::info("{:.3f}", my_num)`). There are no characters after the `ms`, but there should be a newline.
+where X stands for the total number of bytes sent (in kilobytes), Y stands for the rate at which traffic could be written in megabits per second (Mbps), and Z stands for the estimated RTT (in milliseconds). Note X and Z should be integers and Y should be a decimal with **three digits** after the decimal mark (e.g. `spdlog::info("{:.3f}", my_num)`). There are no characters after the `ms`, but there should be a newline.
 
 For example:
 `Sent=6543 KB, Rate=5.234 Mbps, RTT=20ms`
@@ -495,5 +495,6 @@ The deadline for Gradescope submission is the same as the Autograder deadline.
 
 ## Acknowledgements
 This programming assignment is based on Aditya Akella's Assignment 1 from Wisconsin CS 640: Computer Networks and has been modified by several years of previous EECS 489 staff. 
+
 
 


### PR DESCRIPTION
In description of what to log, previously the Readme incorrectly said the client should keep track of number of bytes received and calculate rate that could be read in from network.  Changed to "number of bytes sent" and rate "written" to the network.